### PR TITLE
Fix Missing Class Error

### DIFF
--- a/Provider.php
+++ b/Provider.php
@@ -6,6 +6,7 @@ use Exception;
 use Illuminate\Support\Arr;
 use SocialiteProviders\Manager\OAuth2\AbstractProvider;
 use SocialiteProviders\Manager\OAuth2\User;
+use Laravel\Socialite\Two\InvalidStateException;
 
 class Provider extends AbstractProvider
 {


### PR DESCRIPTION
We were getting a fatal error whenever the provider tried to throw an 'InvalidStateException'. It looks like it needs to be a 'Laravel\Socialite\Two\InvalidStateException', so I'm including that file - which seems to fix the problem.